### PR TITLE
Find & use WebSocket client IP address

### DIFF
--- a/websocket-helpers.js
+++ b/websocket-helpers.js
@@ -1,0 +1,76 @@
+load('sbbsdefs.js');
+
+function wstsGetIPAddress() {
+
+	try {
+
+		var ip = [];
+		var data = [];
+
+		console.lock_input(true);
+		console.telnet_cmd(253, 28); // DO TTYLOC
+
+		var stime = system.timer;
+		while (system.timer - stime < 1) {
+			if (!client.socket.data_waiting) continue;
+			data.push(client.socket.recvBin(1));
+			if (data.length >= 14 &&
+				data[data.length - 3] !== 255 &&
+				data[data.length - 2] === 255 &&
+				data[data.length - 1] === 240
+			) {
+				break;
+			}
+		}
+
+		// Check for a valid reply
+		if (data.length < 14 || // Minimum response length
+			// Should start like this
+			data[0] !== 255 || // IAC
+			data[1] !== 250 || // SB
+			data[2] !== 28 || // TTYLOC
+			data[3] !== 0 || // FORMAT
+			// Should end like this
+			data[data.length - 2] !== 255 || // IAC
+			data[data.length - 1] !== 240 // SE
+		) {
+			throw 'Invalid reply to TTYLOC command.';
+		}
+
+		for (var d = 4; d < data.length - 2; d++) {
+			ip.push(data[d]);
+			if (data[d] === 255) d++;
+		}
+		if (ip.length !== 8) throw 'Invalid reply to TTYLOC command.';
+
+	} catch (err) {
+
+		log(LOG_DEBUG, err);
+
+	} finally {
+
+		console.lock_input(false);
+
+		if (ip.length !== 8) {
+			return;
+		} else {
+			return ip.slice(0, 4).join('.');
+		}
+
+	}
+
+}
+
+function wsrsGetIPAddress() {
+
+	var fn = format('%suser/%04d.web', system.data_dir, un);
+	if (!file_exists(fn)) return;
+	var f = new File(fn);
+	if (!f.open('r')) return;
+	var session = f.iniGetObject();
+	f.close();
+	if (typeof session.ip_address === 'undefined') return;
+
+	return session.ip_address;
+
+}


### PR DESCRIPTION
The new 'exec/websocket-telnet-service.js' in the Synchronet CVS can report the client's ipv4 address to the telnet server upon request.  If the user is on the local/private network and they are on via telnet, we can first try to retrieve their IP address that way; if that fails we can use 'resolve_ip(system.inet_addr)'.

Users on via RLogin from the local/private network may also be WebSocket clients, and if so (and if the system is using my new web UI) we can fetch the user's real IP address from their web session store.  (Again, if that fails we can use 'resolve_ip(system.inet_addr)').

Or if the user is from the local network and a non-IP fallback has been chosen, we'll just use that instead.  Likewise if the user isn't from the local network, just use their reported IP address as before.
