### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+*.asc	eol=crlf
+*.ans	eol=crlf
+*.msg	eol=crlf
+*.txt	eol=crlf
+*.diz	eol=crlf
+*.src	eol=crlf
+*.bin	-text


### PR DESCRIPTION
Preserve CRLF for ansi/ascii files for non-windows platforms.
